### PR TITLE
Support pertelian hd44780.

### DIFF
--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/pkg/lcdproc.inc
@@ -300,6 +300,7 @@ function sync_package_lcdproc() {
 				$config_text .= set_lcd_value("contrast", 1000, 350);
 				break;
 			case "hd44780":
+				$keypad = $lcdproc_config['connection_type'] != 'pertelian';
 				$config_text .= "[{$lcdproc_config['driver']}]\n";
 				$config_text .= "driverpath=/usr/local/lib/lcdproc/\n";
 				$config_text .= "ConnectionType={$lcdproc_config['connection_type']}\n";
@@ -307,14 +308,16 @@ function sync_package_lcdproc() {
 					$config_text .= "Device={$realport}\n";
 					$config_text .= "Port=0x378\n";
 					$config_text .= "Speed=0\n";
-					$config_text .= "Keypad=yes\n";
+					if ($keypad) {
+						$config_text .= "Keypad=yes\n";
+					}
 					$config_text .= set_lcd_value("contrast", 1000, 850);
 					$config_text .= set_lcd_value("brightness", 1000, 800);
 					$config_text .= set_lcd_value("offbrightness", 1000, 0);
 					$config_text .= "Backlight=yes\n";
 					$config_text .= "OutputPort=no\n";
 					$config_text .= "Charmap=hd44780_default\n";
-					$config_text .= "DelayMult=1\n";
+					$config_text .= "DelayMult={$lcdproc_config['delaymult']}\n";
 					$config_text .= "DelayBus=true\n";
 					$config_text .= "Size={$lcdproc_config['size']}\n";
 				}

--- a/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc.php
+++ b/sysutils/pfSense-pkg-LCDproc/files/usr/local/www/packages/lcdproc/lcdproc.php
@@ -43,6 +43,7 @@ if (!isset($pconfig['backlight']))                   $pconfig['backlight']      
 if (!isset($pconfig['outputleds']))                  $pconfig['outputleds']                  = 'no';
 if (!isset($pconfig['mtxorb_type']))                 $pconfig['mtxorb_type']                 = 'lcd'; // specific to Matrix Orbital driver
 if (!isset($pconfig['mtxorb_adjustable_backlight'])) $pconfig['mtxorb_adjustable_backlight'] = true;  // specific to Matrix Orbital driver
+if (!isset($pconfig['delaymult']))                   $pconfig['delaymult']                   = '1';
 
 
 if ($_POST) {
@@ -68,6 +69,7 @@ if ($_POST) {
 		$lcdproc_config['outputleds']                  = $pconfig['outputleds'];
 		$lcdproc_config['mtxorb_type']                 = $pconfig['mtxorb_type'];
 		$lcdproc_config['mtxorb_adjustable_backlight'] = $pconfig['mtxorb_adjustable_backlight'];
+		$lcdproc_config['delaymult']                   = $pconfig['delaymult'];
 				
 		write_config();
 		sync_package_lcdproc();
@@ -263,6 +265,7 @@ $section->add($subsection);
 		var using_HD44780_driver  = driverName_lowercase.indexOf("hd44780") >= 0;
 		using_HD44780_driver     |= jQuery("#driver option:selected").text().toLowerCase().indexOf("hd44780") >= 0;
 		hideInput('connection_type', !using_HD44780_driver); // Hides the entire section
+		hideInput('delaymult', !using_HD44780_driver); // Hides the entire section
 
 		// Hide the Matrix Orbital specific fields when not using the MtxOrb driver		
 		var using_MtxOrb_driver  = driverName_lowercase.indexOf("mtxorb") >= 0;
@@ -294,6 +297,15 @@ $section->addInput(
 		]
 	)
 )->setHelp('Set the port speed.<br />Caution: not all the driver or panels support all the speeds, leave "default" if unsure.');
+
+$section->addInput(
+	new Form_Input(
+		'delaymult',
+		'Delay Multiplier',
+                'text',
+		$pconfig['delaymult'] // Initial value.
+	)
+)->setHelp('Set the delay multiplier. Leave alone if unsure.');
 
 /********* New section *********/
 $form->add($section); 


### PR DESCRIPTION
I have a Pertelian x2040, and, since it has no keypad, and since LCDd refuses to start with that combination, I needed to tweak the php to leave out the Keypad enable. I tried to make it generic, in case other hd44780 gadgets also need this option.

In addition, my Pertelian needs to be able to set DelayMult to a value other than the default, so I added that to the www php, hiding it for all devices other than the hd44780.